### PR TITLE
Use Formatter::width for setting width of document 

### DIFF
--- a/examples/trees.rs
+++ b/examples/trees.rs
@@ -88,27 +88,5 @@ pub fn main() {
     ];
     let example = Tree::node_with_forest("aaaa", &aaas);
 
-    let err_msg = "<buffer is not a utf-8 encoded string>";
-
-    // try writing to stdout
-    {
-        print!("\nwriting to stdout directly:\n");
-        let mut out = io::stdout();
-        example.pretty(&allocator).1.render(70, &mut out)
-        // try writing to memory
-    }.and_then(|()| {
-        print!("\nwriting to string then printing:\n");
-        let mut mem = Vec::new();
-        example
-            .pretty(&allocator)
-            .1
-            .render(70, &mut mem)
-            // print to console from memory
-            .map(|()| {
-                let res = str::from_utf8(&mem).unwrap_or(err_msg);
-                println!("{}", res)
-            })
-        // print an error if anything failed
-    })
-        .unwrap_or_else(|err| println!("error: {}", err));
+    println!("{:70}", example.pretty(&allocator).1.pretty());
 }


### PR DESCRIPTION
Closes #38

This uses the `fmt::Formatter::width` setting to control the pretty printing width, defaulting to `std::usize::MAX` if it is not set.

For example:

```rust
use pretty::Doc;
let doc = Doc::group(
    Doc::text("hello").append(Doc::space()).append(Doc::text("world"))
);
assert_eq!(format!("{}", doc.pretty()), "hello world");
assert_eq!(format!("{:80}", doc.pretty()), "hello world");
assert_eq!(format!("{expr:width$}", expr = doc.pretty(), width = 80), "hello world");
```

I've been doing this manually [in Pikelet](https://github.com/brendanzab/pikelet/blob/881544c66e09beec2cb4689da0895e97fa5c1159/src/syntax/core/mod.rs#L181-L187), and think it would be a nice change! It's a breaking change to the API though.

I also took the time to restructure the modules so that it reads more like a regular Rust project.