### PR TITLE
Cleanups

### DIFF
--- a/benches/trees.rs
+++ b/benches/trees.rs
@@ -8,14 +8,14 @@ extern crate typed_arena;
 use std::io;
 
 use pretty::BoxAllocator;
-use typed_arena::Arena;
 use trees::Tree;
+use typed_arena::Arena;
 
 #[path = "../examples/trees.rs"]
 mod trees;
 
 macro_rules! bench_trees {
-    ($b: expr, $out: expr, $allocator: expr, $size: expr) => {{
+    ($b:expr, $out:expr, $allocator:expr, $size:expr) => {{
         let arena = Arena::new();
         let b = $b;
         let mut out = $out;
@@ -24,22 +24,22 @@ macro_rules! bench_trees {
         let mut example = Tree::node("aaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
 
         for _ in 0..size {
-            let bbbbbbs = arena.alloc_extend([
-                example,
-                Tree::node("dd"),
-            ].iter().cloned());
+            let bbbbbbs = arena.alloc_extend([example, Tree::node("dd")].iter().cloned());
 
-            let ffffs = arena.alloc_extend([
-                Tree::node("gg"),
-                Tree::node("hhh"),
-                Tree::node("ii"),
-            ].iter().cloned());
+            let ffffs = arena.alloc_extend(
+                [Tree::node("gg"), Tree::node("hhh"), Tree::node("ii")]
+                    .iter()
+                    .cloned(),
+            );
 
-            let aaas = arena.alloc_extend([
-                Tree::node_with_forest("bbbbbb", bbbbbbs),
-                Tree::node("eee"),
-                Tree::node_with_forest("ffff", ffffs),
-            ].iter().cloned());
+            let aaas = arena.alloc_extend(
+                [
+                    Tree::node_with_forest("bbbbbb", bbbbbbs),
+                    Tree::node("eee"),
+                    Tree::node_with_forest("ffff", ffffs),
+                ].iter()
+                    .cloned(),
+            );
 
             example = Tree::node_with_forest("aaa", aaas);
         }
@@ -47,9 +47,13 @@ macro_rules! bench_trees {
         let allocator = $allocator;
 
         b.iter(|| {
-            example.pretty::<(), _>(&allocator).1.render(70, &mut out).unwrap();
+            example
+                .pretty::<_, ()>(&allocator)
+                .1
+                .render(70, &mut out)
+                .unwrap();
         });
-    }}
+    }};
 }
 
 #[bench]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,9 +48,9 @@
 //! impl SExp {
 //!     /// Return a pretty printed format of self.
 //!     pub fn to_doc(&self) -> Doc<BoxDoc<()>> {
-//!         match self {
-//!             &Atom(x) => Doc::as_string(x),
-//!             &List(ref xs) =>
+//!         match *self {
+//!             Atom(ref x) => Doc::as_string(x),
+//!             List(ref xs) =>
 //!                 Doc::text("(")
 //!                     .append(Doc::intersperse(xs.into_iter().map(|x| x.to_doc()), Doc::space()).nest(1).group())
 //!                     .append(Doc::text(")"))
@@ -73,9 +73,9 @@
 //! # impl SExp {
 //! #     /// Return a pretty printed format of self.
 //! #     pub fn to_doc(&self) -> Doc<BoxDoc<()>> {
-//! #         match self {
-//! #             &Atom(x) => Doc::as_string(x),
-//! #             &List(ref xs) =>
+//! #         match *self {
+//! #             Atom(ref x) => Doc::as_string(x),
+//! #             List(ref xs) =>
 //! #                 Doc::text("(")
 //! #                     .append(Doc::intersperse(xs.into_iter().map(|x| x.to_doc()), Doc::space()).nest(1).group())
 //! #                     .append(Doc::text(")"))
@@ -105,9 +105,9 @@
 //! # impl SExp {
 //! #     /// Return a pretty printed format of self.
 //! #     pub fn to_doc(&self) -> Doc<BoxDoc<()>> {
-//! #         match self {
-//! #             &Atom(x) => Doc::as_string(x),
-//! #             &List(ref xs) =>
+//! #         match *self {
+//! #             Atom(ref x) => Doc::as_string(x),
+//! #             List(ref xs) =>
 //! #                 Doc::text("(")
 //! #                     .append(Doc::intersperse(xs.into_iter().map(|x| x.to_doc()), Doc::space()).nest(1).group())
 //! #                     .append(Doc::text(")"))
@@ -182,7 +182,7 @@ impl<'a, A, B> Doc<'a, A, B> {
     ///
     /// The given text must not contain line breaks.
     #[inline]
-    pub fn as_string<T: ToString>(t: T) -> Doc<'a, A, B> {
+    pub fn as_string<T: ToString>(t: &T) -> Doc<'a, A, B> {
         Doc::text(t.to_string())
     }
 
@@ -443,7 +443,7 @@ pub trait DocAllocator<'a, A = ()> {
     ///
     /// The given text must not contain line breaks.
     #[inline]
-    fn as_string<T: ToString>(&'a self, t: T) -> DocBuilder<'a, Self, A> {
+    fn as_string<T: ToString>(&'a self, t: &T) -> DocBuilder<'a, Self, A> {
         self.text(t.to_string())
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -241,16 +241,18 @@ impl<'a, A> Doc<'a, BoxDoc<'a, A>, A> {
         S: Into<Doc<'a, BoxDoc<'a, A>, A>> + Clone,
         A: Clone,
     {
-        let separator = separator.into();
         let mut result = Doc::nil();
         let mut iter = docs.into_iter();
+
         if let Some(first) = iter.next() {
             result = result.append(first);
+
+            for doc in iter {
+                result = result.append(separator.clone());
+                result = result.append(doc);
+            }
         }
-        for doc in iter {
-            result = result.append(separator.clone());
-            result = result.append(doc);
-        }
+
         result
     }
 
@@ -481,13 +483,16 @@ pub trait DocAllocator<'a, A = ()> {
     {
         let mut result = self.nil();
         let mut iter = docs.into_iter();
+
         if let Some(first) = iter.next() {
             result = result.append(first);
+
+            for doc in iter {
+                result = result.append(separator.clone());
+                result = result.append(doc);
+            }
         }
-        for doc in iter {
-            result = result.append(separator.clone());
-            result = result.append(doc);
-        }
+
         result
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,6 +154,10 @@ use termcolor::{ColorSpec, WriteColor};
 
 mod render;
 
+#[cfg(feature = "termcolor")]
+pub use self::render::TermColored;
+pub use self::render::{FmtWrite, IoWrite, Render, RenderAnnotated};
+
 /// The concrete document type. This type is not meant to be used directly. Instead use the static
 /// functions on `Doc` or the methods on an `DocAllocator`.
 ///
@@ -309,7 +313,7 @@ impl<'a, B, A> Doc<'a, B, A> {
         B: Deref<Target = Doc<'b, B, A>>,
         W: ?Sized + io::Write,
     {
-        self.render_raw(width, &mut render::IoWrite::new(out))
+        self.render_raw(width, &mut IoWrite::new(out))
     }
 
     /// Writes a rendered document to a `std::fmt::Write` object.
@@ -319,7 +323,7 @@ impl<'a, B, A> Doc<'a, B, A> {
         B: Deref<Target = Doc<'b, B, A>>,
         W: ?Sized + fmt::Write,
     {
-        self.render_raw(width, &mut render::FmtWrite::new(out))
+        self.render_raw(width, &mut FmtWrite::new(out))
     }
 
     /// Writes a rendered document to a `RenderAnnotated<A>` object.
@@ -358,7 +362,7 @@ impl<'a, B> Doc<'a, B, ColorSpec> {
         B: Deref<Target = Doc<'b, B, ColorSpec>>,
         W: WriteColor,
     {
-        render::best(self, width, &mut render::TermColored::new(out))
+        render::best(self, width, &mut TermColored::new(out))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -588,6 +588,9 @@ impl<'a, A> DocAllocator<'a, A> for Arena<'a, A> {
     #[inline]
     fn alloc(&'a self, doc: Doc<'a, Self::Doc, A>) -> Self::Doc {
         RefDoc(match doc {
+            // Return 'static references for unit variants to save a small
+            // amount of space in the arena
+            Doc::Nil => &Doc::Nil,
             Doc::Space => &Doc::Space,
             Doc::Newline => &Doc::Newline,
             _ => Arena::alloc(self, doc),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,258 +145,37 @@
 pub extern crate termcolor;
 extern crate typed_arena;
 
-use doc::Doc::{Annotated, Append, Group, Nest, Newline, Nil, Space, Text};
 use std::borrow::Cow;
 use std::fmt;
+use std::io;
 use std::ops::Deref;
+#[cfg(feature = "termcolor")]
+use termcolor::{ColorSpec, WriteColor};
 
-mod doc;
+mod render;
 
-#[derive(Clone, Eq, Ord, PartialEq, PartialOrd)]
-pub struct BoxDoc<'a, A>(Box<doc::Doc<'a, BoxDoc<'a, A>, A>>);
-
-impl<'a, A> fmt::Debug for BoxDoc<'a, A>
-where
-    A: fmt::Debug,
-{
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.0.fmt(f)
-    }
+/// The concrete document type. This type is not meant to be used directly. Instead use the static
+/// functions on `Doc` or the methods on an `DocAllocator`.
+///
+/// The `B` parameter is used to abstract over pointers to `Doc`. See `RefDoc` and `BoxDoc` for how
+/// it is used
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub enum Doc<'a, B, A = ()> {
+    Nil,
+    Append(B, B),
+    Group(B),
+    Nest(usize, B),
+    Space,
+    Newline,
+    Text(Cow<'a, str>),
+    Annotated(A, B),
 }
-
-impl<'a, A> BoxDoc<'a, A> {
-    fn new(doc: doc::Doc<'a, BoxDoc<'a, A>, A>) -> BoxDoc<'a, A> {
-        BoxDoc(Box::new(doc))
-    }
-}
-
-impl<'a, A> Deref for BoxDoc<'a, A> {
-    type Target = doc::Doc<'a, BoxDoc<'a, A>, A>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-/// The `DocBuilder` type allows for convenient appending of documents even for arena allocated
-/// documents by storing the arena inline.
-#[derive(Eq, Ord, PartialEq, PartialOrd)]
-pub struct DocBuilder<'a, D: ?Sized, A = ()>(pub &'a D, pub doc::Doc<'a, D::Doc, A>)
-where
-    D: DocAllocator<'a, A> + 'a;
-
-impl<'a, A, D: DocAllocator<'a, A> + 'a> Clone for DocBuilder<'a, D, A>
-where
-    A: Clone,
-    D::Doc: Clone,
-{
-    fn clone(&self) -> Self {
-        DocBuilder(self.0, self.1.clone())
-    }
-}
-
-impl<'a, D: ?Sized, A> Into<doc::Doc<'a, D::Doc, A>> for DocBuilder<'a, D, A>
-where
-    D: DocAllocator<'a, A>,
-{
-    fn into(self) -> doc::Doc<'a, D::Doc, A> {
-        self.1
-    }
-}
-
-/// The `DocAllocator` trait abstracts over a type which can allocate (pointers to) `Doc`.
-pub trait DocAllocator<'a, A = ()> {
-    type Doc: Deref<Target = doc::Doc<'a, Self::Doc, A>>;
-
-    fn alloc(&'a self, doc::Doc<'a, Self::Doc, A>) -> Self::Doc;
-
-    /// Allocate an empty document.
-    #[inline]
-    fn nil(&'a self) -> DocBuilder<'a, Self, A> {
-        DocBuilder(self, Nil)
-    }
-
-    /// Allocate a single newline.
-    #[inline]
-    fn newline(&'a self) -> DocBuilder<'a, Self, A> {
-        DocBuilder(self, Newline)
-    }
-
-    /// Allocate a single space.
-    #[inline]
-    fn space(&'a self) -> DocBuilder<'a, Self, A> {
-        DocBuilder(self, Space)
-    }
-
-    /// Allocate a document containing the text `t.to_string()`.
-    ///
-    /// The given text must not contain line breaks.
-    #[inline]
-    fn as_string<T: ToString>(&'a self, t: T) -> DocBuilder<'a, Self, A> {
-        self.text(t.to_string())
-    }
-
-    /// Allocate a document containing the given text.
-    ///
-    /// The given text must not contain line breaks.
-    #[inline]
-    fn text<T: Into<Cow<'a, str>>>(&'a self, data: T) -> DocBuilder<'a, Self, A> {
-        let text = data.into();
-        DocBuilder(self, Text(text))
-    }
-
-    /// Allocate a document concatenating the given documents.
-    #[inline]
-    fn concat<I>(&'a self, docs: I) -> DocBuilder<'a, Self, A>
-    where
-        I: IntoIterator,
-        I::Item: Into<doc::Doc<'a, Self::Doc, A>>,
-    {
-        docs.into_iter().fold(self.nil(), |a, b| a.append(b))
-    }
-
-    /// Allocate a document that intersperses the given separator `S` between the given documents
-    /// `[A, B, C, ..., Z]`, yielding `[A, S, B, S, C, S, ..., S, Z]`.
-    ///
-    /// Compare [the `intersperse` method from the `itertools` crate](https://docs.rs/itertools/0.5.9/itertools/trait.Itertools.html#method.intersperse).
-    #[inline]
-    fn intersperse<I, S>(&'a self, docs: I, separator: S) -> DocBuilder<'a, Self, A>
-    where
-        I: IntoIterator,
-        I::Item: Into<doc::Doc<'a, Self::Doc, A>>,
-        S: Into<doc::Doc<'a, Self::Doc, A>> + Clone,
-    {
-        let mut result = self.nil();
-        let mut iter = docs.into_iter();
-        if let Some(first) = iter.next() {
-            result = result.append(first);
-        }
-        for doc in iter {
-            result = result.append(separator.clone());
-            result = result.append(doc);
-        }
-        result
-    }
-}
-
-impl<'a, 's, D: ?Sized, A> DocBuilder<'a, D, A>
-where
-    D: DocAllocator<'a, A>,
-{
-    /// Append the given document after this document.
-    #[inline]
-    pub fn append<B>(self, that: B) -> DocBuilder<'a, D, A>
-    where
-        B: Into<doc::Doc<'a, D::Doc, A>>,
-    {
-        let DocBuilder(allocator, this) = self;
-        let that = that.into();
-        let doc = match (this, that) {
-            (Nil, that) => that,
-            (this, Nil) => this,
-            (this, that) => Append(allocator.alloc(this), allocator.alloc(that)),
-        };
-        DocBuilder(allocator, doc)
-    }
-
-    /// Mark this document as a group.
-    ///
-    /// Groups are layed out on a single line if possible.  Within a group, all basic documents with
-    /// several possible layouts are assigned the same layout, that is, they are all layed out
-    /// horizontally and combined into a one single line, or they are each layed out on their own
-    /// line.
-    #[inline]
-    pub fn group(self) -> DocBuilder<'a, D, A> {
-        let DocBuilder(allocator, this) = self;
-        DocBuilder(allocator, Group(allocator.alloc(this)))
-    }
-
-    /// Increase the indentation level of this document.
-    #[inline]
-    pub fn nest(self, offset: usize) -> DocBuilder<'a, D, A> {
-        if offset == 0 {
-            return self;
-        }
-        let DocBuilder(allocator, this) = self;
-        DocBuilder(allocator, Nest(offset, allocator.alloc(this)))
-    }
-
-    #[inline]
-    pub fn annotate(self, ann: A) -> DocBuilder<'a, D, A> {
-        let DocBuilder(allocator, this) = self;
-        DocBuilder(allocator, Annotated(ann, allocator.alloc(this)))
-    }
-}
-
-/// Newtype wrapper for `&doc::Doc`
-#[derive(Clone, Eq, Ord, PartialEq, PartialOrd)]
-pub struct RefDoc<'a, A: 'a>(&'a doc::Doc<'a, RefDoc<'a, A>, A>);
-
-impl<'a, A> fmt::Debug for RefDoc<'a, A>
-where
-    A: fmt::Debug,
-{
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.0.fmt(f)
-    }
-}
-
-impl<'a, A> Deref for RefDoc<'a, A> {
-    type Target = doc::Doc<'a, RefDoc<'a, A>, A>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-/// An arena which can be used to allocate `Doc` values.
-pub type Arena<'a, A = ()> = typed_arena::Arena<doc::Doc<'a, RefDoc<'a, A>, A>>;
-
-impl<'a, D, A> DocAllocator<'a, A> for &'a D
-where
-    D: ?Sized + DocAllocator<'a, A>,
-{
-    type Doc = D::Doc;
-
-    #[inline]
-    fn alloc(&'a self, doc: doc::Doc<'a, Self::Doc, A>) -> Self::Doc {
-        (**self).alloc(doc)
-    }
-}
-
-impl<'a, A> DocAllocator<'a, A> for Arena<'a, A> {
-    type Doc = RefDoc<'a, A>;
-
-    #[inline]
-    fn alloc(&'a self, doc: doc::Doc<'a, Self::Doc, A>) -> Self::Doc {
-        RefDoc(match doc {
-            Space => &Doc::Space,
-            Newline => &Doc::Newline,
-            _ => Arena::alloc(self, doc),
-        })
-    }
-}
-
-pub struct BoxAllocator;
-
-static BOX_ALLOCATOR: BoxAllocator = BoxAllocator;
-
-impl<'a, A> DocAllocator<'a, A> for BoxAllocator {
-    type Doc = BoxDoc<'a, A>;
-
-    #[inline]
-    fn alloc(&'a self, doc: doc::Doc<'a, Self::Doc, A>) -> Self::Doc {
-        BoxDoc::new(doc)
-    }
-}
-
-pub use doc::Doc;
 
 impl<'a, A, B> Doc<'a, A, B> {
     /// An empty document.
     #[inline]
     pub fn nil() -> Doc<'a, A, B> {
-        Nil
+        Doc::Nil
     }
 
     /// The text `t.to_string()`.
@@ -410,20 +189,20 @@ impl<'a, A, B> Doc<'a, A, B> {
     /// A single newline.
     #[inline]
     pub fn newline() -> Doc<'a, A, B> {
-        Newline
+        Doc::Newline
     }
 
     /// The given text, which must not contain line breaks.
     #[inline]
     pub fn text<T: Into<Cow<'a, str>>>(data: T) -> Doc<'a, A, B> {
         let text = data.into();
-        Text(text)
+        Doc::Text(text)
     }
 
     /// A space.
     #[inline]
     pub fn space() -> Doc<'a, A, B> {
-        Space
+        Doc::Space
     }
 }
 
@@ -487,6 +266,332 @@ impl<'a, A> Doc<'a, BoxDoc<'a, A>, A> {
     #[inline]
     pub fn annotate(self, ann: A) -> Doc<'a, BoxDoc<'a, A>, A> {
         DocBuilder(&BOX_ALLOCATOR, self).annotate(ann).into()
+    }
+}
+
+impl<'a, B, A, S> From<S> for Doc<'a, B, A>
+where
+    S: Into<Cow<'a, str>>,
+{
+    fn from(s: S) -> Doc<'a, B, A> {
+        Doc::Text(s.into())
+    }
+}
+
+pub struct Pretty<'a, D, A>
+where
+    A: 'a,
+    D: 'a,
+{
+    doc: &'a Doc<'a, D, A>,
+    width: usize,
+}
+
+impl<'a, D, A> fmt::Display for Pretty<'a, D, A>
+where
+    D: Deref<Target = Doc<'a, D, A>>,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.doc.render_fmt(self.width, f)
+    }
+}
+
+impl<'a, B, A> Doc<'a, B, A> {
+    /// Writes a rendered document to a `std::io::Write` object.
+    #[inline]
+    pub fn render<'b, W>(&'b self, width: usize, out: &mut W) -> io::Result<()>
+    where
+        B: Deref<Target = Doc<'b, B, A>>,
+        W: ?Sized + io::Write,
+    {
+        self.render_raw(width, &mut render::IoWrite(out))
+    }
+
+    /// Writes a rendered document to a `std::fmt::Write` object.
+    #[inline]
+    pub fn render_fmt<'b, W>(&'b self, width: usize, out: &mut W) -> fmt::Result
+    where
+        B: Deref<Target = Doc<'b, B, A>>,
+        W: ?Sized + fmt::Write,
+    {
+        self.render_raw(width, &mut render::FmtWrite(out))
+    }
+
+    /// Writes a rendered document to a `RenderAnnotated<A>` object.
+    #[inline]
+    pub fn render_raw<'b, W>(&'b self, width: usize, out: &mut W) -> Result<(), W::Error>
+    where
+        B: Deref<Target = Doc<'b, B, A>>,
+        W: ?Sized + render::RenderAnnotated<A>,
+    {
+        render::best(self, width, out)
+    }
+
+    /// Returns a value which implements `std::fmt::Display`
+    ///
+    /// ```
+    /// use pretty::Doc;
+    /// let doc = Doc::<_>::group(
+    ///     Doc::text("hello").append(Doc::space()).append(Doc::text("world"))
+    /// );
+    /// assert_eq!(format!("{}", doc.pretty(80)), "hello world");
+    /// ```
+    #[inline]
+    pub fn pretty<'b>(&'b self, width: usize) -> Pretty<'b, B, A>
+    where
+        B: Deref<Target = Doc<'b, B, A>>,
+    {
+        Pretty { doc: self, width }
+    }
+}
+
+#[cfg(feature = "termcolor")]
+impl<'a, B> Doc<'a, B, ColorSpec> {
+    #[inline]
+    pub fn render_colored<'b, W>(&'b self, width: usize, out: W) -> io::Result<()>
+    where
+        B: Deref<Target = Doc<'b, B, ColorSpec>>,
+        W: WriteColor,
+    {
+        render::best(self, width, &mut render::TermColored::new(out))
+    }
+}
+
+#[derive(Clone, Eq, Ord, PartialEq, PartialOrd)]
+pub struct BoxDoc<'a, A>(Box<Doc<'a, BoxDoc<'a, A>, A>>);
+
+impl<'a, A> fmt::Debug for BoxDoc<'a, A>
+where
+    A: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl<'a, A> BoxDoc<'a, A> {
+    fn new(doc: Doc<'a, BoxDoc<'a, A>, A>) -> BoxDoc<'a, A> {
+        BoxDoc(Box::new(doc))
+    }
+}
+
+impl<'a, A> Deref for BoxDoc<'a, A> {
+    type Target = Doc<'a, BoxDoc<'a, A>, A>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+/// The `DocBuilder` type allows for convenient appending of documents even for arena allocated
+/// documents by storing the arena inline.
+#[derive(Eq, Ord, PartialEq, PartialOrd)]
+pub struct DocBuilder<'a, D: ?Sized, A = ()>(pub &'a D, pub Doc<'a, D::Doc, A>)
+where
+    D: DocAllocator<'a, A> + 'a;
+
+impl<'a, A, D: DocAllocator<'a, A> + 'a> Clone for DocBuilder<'a, D, A>
+where
+    A: Clone,
+    D::Doc: Clone,
+{
+    fn clone(&self) -> Self {
+        DocBuilder(self.0, self.1.clone())
+    }
+}
+
+impl<'a, D: ?Sized, A> Into<Doc<'a, D::Doc, A>> for DocBuilder<'a, D, A>
+where
+    D: DocAllocator<'a, A>,
+{
+    fn into(self) -> Doc<'a, D::Doc, A> {
+        self.1
+    }
+}
+
+/// The `DocAllocator` trait abstracts over a type which can allocate (pointers to) `Doc`.
+pub trait DocAllocator<'a, A = ()> {
+    type Doc: Deref<Target = Doc<'a, Self::Doc, A>>;
+
+    fn alloc(&'a self, Doc<'a, Self::Doc, A>) -> Self::Doc;
+
+    /// Allocate an empty document.
+    #[inline]
+    fn nil(&'a self) -> DocBuilder<'a, Self, A> {
+        DocBuilder(self, Doc::Nil)
+    }
+
+    /// Allocate a single newline.
+    #[inline]
+    fn newline(&'a self) -> DocBuilder<'a, Self, A> {
+        DocBuilder(self, Doc::Newline)
+    }
+
+    /// Allocate a single space.
+    #[inline]
+    fn space(&'a self) -> DocBuilder<'a, Self, A> {
+        DocBuilder(self, Doc::Space)
+    }
+
+    /// Allocate a document containing the text `t.to_string()`.
+    ///
+    /// The given text must not contain line breaks.
+    #[inline]
+    fn as_string<T: ToString>(&'a self, t: T) -> DocBuilder<'a, Self, A> {
+        self.text(t.to_string())
+    }
+
+    /// Allocate a document containing the given text.
+    ///
+    /// The given text must not contain line breaks.
+    #[inline]
+    fn text<T: Into<Cow<'a, str>>>(&'a self, data: T) -> DocBuilder<'a, Self, A> {
+        let text = data.into();
+        DocBuilder(self, Doc::Text(text))
+    }
+
+    /// Allocate a document concatenating the given documents.
+    #[inline]
+    fn concat<I>(&'a self, docs: I) -> DocBuilder<'a, Self, A>
+    where
+        I: IntoIterator,
+        I::Item: Into<Doc<'a, Self::Doc, A>>,
+    {
+        docs.into_iter().fold(self.nil(), |a, b| a.append(b))
+    }
+
+    /// Allocate a document that intersperses the given separator `S` between the given documents
+    /// `[A, B, C, ..., Z]`, yielding `[A, S, B, S, C, S, ..., S, Z]`.
+    ///
+    /// Compare [the `intersperse` method from the `itertools` crate](https://docs.rs/itertools/0.5.9/itertools/trait.Itertools.html#method.intersperse).
+    #[inline]
+    fn intersperse<I, S>(&'a self, docs: I, separator: S) -> DocBuilder<'a, Self, A>
+    where
+        I: IntoIterator,
+        I::Item: Into<Doc<'a, Self::Doc, A>>,
+        S: Into<Doc<'a, Self::Doc, A>> + Clone,
+    {
+        let mut result = self.nil();
+        let mut iter = docs.into_iter();
+        if let Some(first) = iter.next() {
+            result = result.append(first);
+        }
+        for doc in iter {
+            result = result.append(separator.clone());
+            result = result.append(doc);
+        }
+        result
+    }
+}
+
+impl<'a, 's, D: ?Sized, A> DocBuilder<'a, D, A>
+where
+    D: DocAllocator<'a, A>,
+{
+    /// Append the given document after this document.
+    #[inline]
+    pub fn append<B>(self, that: B) -> DocBuilder<'a, D, A>
+    where
+        B: Into<Doc<'a, D::Doc, A>>,
+    {
+        let DocBuilder(allocator, this) = self;
+        let that = that.into();
+        let doc = match (this, that) {
+            (Doc::Nil, that) => that,
+            (this, Doc::Nil) => this,
+            (this, that) => Doc::Append(allocator.alloc(this), allocator.alloc(that)),
+        };
+        DocBuilder(allocator, doc)
+    }
+
+    /// Mark this document as a group.
+    ///
+    /// Groups are layed out on a single line if possible.  Within a group, all basic documents with
+    /// several possible layouts are assigned the same layout, that is, they are all layed out
+    /// horizontally and combined into a one single line, or they are each layed out on their own
+    /// line.
+    #[inline]
+    pub fn group(self) -> DocBuilder<'a, D, A> {
+        let DocBuilder(allocator, this) = self;
+        DocBuilder(allocator, Doc::Group(allocator.alloc(this)))
+    }
+
+    /// Increase the indentation level of this document.
+    #[inline]
+    pub fn nest(self, offset: usize) -> DocBuilder<'a, D, A> {
+        if offset == 0 {
+            return self;
+        }
+        let DocBuilder(allocator, this) = self;
+        DocBuilder(allocator, Doc::Nest(offset, allocator.alloc(this)))
+    }
+
+    #[inline]
+    pub fn annotate(self, ann: A) -> DocBuilder<'a, D, A> {
+        let DocBuilder(allocator, this) = self;
+        DocBuilder(allocator, Doc::Annotated(ann, allocator.alloc(this)))
+    }
+}
+
+/// Newtype wrapper for `&Doc`
+#[derive(Clone, Eq, Ord, PartialEq, PartialOrd)]
+pub struct RefDoc<'a, A: 'a>(&'a Doc<'a, RefDoc<'a, A>, A>);
+
+impl<'a, A> fmt::Debug for RefDoc<'a, A>
+where
+    A: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl<'a, A> Deref for RefDoc<'a, A> {
+    type Target = Doc<'a, RefDoc<'a, A>, A>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+/// An arena which can be used to allocate `Doc` values.
+pub type Arena<'a, A = ()> = typed_arena::Arena<Doc<'a, RefDoc<'a, A>, A>>;
+
+impl<'a, D, A> DocAllocator<'a, A> for &'a D
+where
+    D: ?Sized + DocAllocator<'a, A>,
+{
+    type Doc = D::Doc;
+
+    #[inline]
+    fn alloc(&'a self, doc: Doc<'a, Self::Doc, A>) -> Self::Doc {
+        (**self).alloc(doc)
+    }
+}
+
+impl<'a, A> DocAllocator<'a, A> for Arena<'a, A> {
+    type Doc = RefDoc<'a, A>;
+
+    #[inline]
+    fn alloc(&'a self, doc: Doc<'a, Self::Doc, A>) -> Self::Doc {
+        RefDoc(match doc {
+            Doc::Space => &Doc::Space,
+            Doc::Newline => &Doc::Newline,
+            _ => Arena::alloc(self, doc),
+        })
+    }
+}
+
+pub struct BoxAllocator;
+
+static BOX_ALLOCATOR: BoxAllocator = BoxAllocator;
+
+impl<'a, A> DocAllocator<'a, A> for BoxAllocator {
+    type Doc = BoxDoc<'a, A>;
+
+    #[inline]
+    fn alloc(&'a self, doc: Doc<'a, Self::Doc, A>) -> Self::Doc {
+        BoxDoc::new(doc)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -309,7 +309,7 @@ impl<'a, B, A> Doc<'a, B, A> {
         B: Deref<Target = Doc<'b, B, A>>,
         W: ?Sized + io::Write,
     {
-        self.render_raw(width, &mut render::IoWrite(out))
+        self.render_raw(width, &mut render::IoWrite::new(out))
     }
 
     /// Writes a rendered document to a `std::fmt::Write` object.
@@ -319,7 +319,7 @@ impl<'a, B, A> Doc<'a, B, A> {
         B: Deref<Target = Doc<'b, B, A>>,
         W: ?Sized + fmt::Write,
     {
-        self.render_raw(width, &mut render::FmtWrite(out))
+        self.render_raw(width, &mut render::FmtWrite::new(out))
     }
 
     /// Writes a rendered document to a `RenderAnnotated<A>` object.

--- a/src/render.rs
+++ b/src/render.rs
@@ -249,8 +249,8 @@ where
         false
     }
 
-    let mut pos = 0usize;
-    let mut bcmds = vec![(0usize, Mode::Break, doc)];
+    let mut pos = 0;
+    let mut bcmds = vec![(0, Mode::Break, doc)];
     let mut fcmds = vec![];
     let mut annotation_levels = vec![];
 

--- a/src/render.rs
+++ b/src/render.rs
@@ -175,7 +175,7 @@ where
     where
         W: ?Sized + Render,
     {
-        try!(out.write_str_all("\n"));
+        out.write_str_all("\n")?;
         write_spaces(ind, out)
     }
 
@@ -192,7 +192,7 @@ where
         let mut inserted = 0;
         while inserted < spaces {
             let insert = cmp::min(SPACES.len(), spaces - inserted);
-            inserted += try!(out.write_str(&SPACES[..insert]));
+            inserted += out.write_str(&SPACES[..insert])?;
         }
 
         Ok(())
@@ -301,15 +301,15 @@ where
             }
             Doc::Space => match mode {
                 Mode::Flat => {
-                    try!(write_spaces(1, out));
+                    write_spaces(1, out)?;
                 }
                 Mode::Break => {
-                    try!(write_newline(ind, out));
+                    write_newline(ind, out)?;
                     pos = ind;
                 }
             },
             Doc::Newline => {
-                try!(write_newline(ind, out));
+                write_newline(ind, out)?;
                 pos = ind;
 
                 // Since this newline caused an early break we don't know if the remaining
@@ -332,11 +332,11 @@ where
                 }
             }
             Doc::Text(ref s) => {
-                try!(out.write_str_all(s));
+                out.write_str_all(s)?;
                 pos += s.len();
             }
             Doc::Annotated(ref ann, ref doc) => {
-                try!(out.push_annotation(ann));
+                out.push_annotation(ann)?;
                 annotation_levels.push(bcmds.len());
                 bcmds.push((ind, mode, doc));
             }
@@ -344,7 +344,7 @@ where
 
         if annotation_levels.last() == Some(&bcmds.len()) {
             annotation_levels.pop();
-            try!(out.pop_annotation());
+            out.pop_annotation()?;
         }
     }
 

--- a/src/render.rs
+++ b/src/render.rs
@@ -158,9 +158,9 @@ where
 }
 
 #[inline]
-pub fn best<'a, W, B, A>(doc: &'a Doc<'a, B, A>, width: usize, out: &mut W) -> Result<(), W::Error>
+pub fn best<'a, W, T, A>(doc: &'a Doc<'a, T, A>, width: usize, out: &mut W) -> Result<(), W::Error>
 where
-    B: Deref<Target = Doc<'a, B, A>>,
+    T: Deref<Target = Doc<'a, T, A>>,
     W: ?Sized + RenderAnnotated<A>,
 {
     #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
@@ -169,7 +169,7 @@ where
         Flat,
     }
 
-    type Cmd<'a, B, A> = (usize, Mode, &'a Doc<'a, B, A>);
+    type Cmd<'a, T, A> = (usize, Mode, &'a Doc<'a, T, A>);
 
     fn write_newline<W>(ind: usize, out: &mut W) -> Result<(), W::Error>
     where
@@ -199,14 +199,14 @@ where
     }
 
     #[inline]
-    fn fitting<'a, B, A>(
-        next: Cmd<'a, B, A>,
-        bcmds: &[Cmd<'a, B, A>],
-        fcmds: &mut Vec<Cmd<'a, B, A>>,
+    fn fitting<'a, T, A>(
+        next: Cmd<'a, T, A>,
+        bcmds: &[Cmd<'a, T, A>],
+        fcmds: &mut Vec<Cmd<'a, T, A>>,
         mut rem: isize,
     ) -> bool
     where
-        B: Deref<Target = Doc<'a, B, A>>,
+        T: Deref<Target = Doc<'a, T, A>>,
     {
         let mut bidx = bcmds.len();
         fcmds.clear(); // clear from previous calls from best


### PR DESCRIPTION
This renames the `doc` module to `render`, and moves the `Doc` type to the top level, hopefully making the code easier to understand in the process.

`Doc::{append, intersperse}` now take `Into<Doc<'a, BoxDoc<'a, A>, A>>`, which is consistent with the corresponding methods on `DocAllocator`.

The `as_string` methods now take references, because they don't consume their arguments. They should probably renamed, or even removed because it they don't really fit with Rust's naming conventions.

I also exposed the rendering traits and data types to actually allow `Doc::render_raw` to be called.