### PR TITLE
feat: Add the FlatAlt document

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -461,6 +461,25 @@ pub trait DocAllocator<'a, A = ()> {
     }
 
     /// Acts like `space` but behaves like `nil` if grouped on a single line
+    ///
+    /// ```
+    /// use pretty::Doc;
+    ///
+    /// let doc = Doc::<_>::group(
+    ///     Doc::text("(")
+    ///         .append(
+    ///             Doc::space_()
+    ///                 .append(Doc::text("test"))
+    ///                 .append(Doc::space())
+    ///                 .append(Doc::text("test"))
+    ///                 .nest(2),
+    ///         )
+    ///         .append(Doc::space_())
+    ///         .append(Doc::text(")")),
+    /// );
+    /// assert_eq!(doc.pretty(5).to_string(), "(\n  test\n  test\n)");
+    /// assert_eq!(doc.pretty(100).to_string(), "(test test)");
+    /// ```
     #[inline]
     fn space_(&'a self) -> DocBuilder<'a, Self, A> {
         self.newline().flat_alt(self.nil())
@@ -775,24 +794,5 @@ mod tests {
         );
 
         test!(doc, "test\ntest");
-    }
-
-    #[test]
-    fn tuple() {
-        let doc = Doc::<_>::group(
-            Doc::text("(")
-                .append(
-                    Doc::space_()
-                        .append(Doc::text("test"))
-                        .append(Doc::space())
-                        .append(Doc::text("test"))
-                        .nest(2),
-                )
-                .append(Doc::space_())
-                .append(Doc::text(")")),
-        );
-
-        test!(5, doc, "(\n  test\n  test\n)");
-        test!(100, doc, "(test test)");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -168,6 +168,7 @@ pub enum Doc<'a, T, A = ()> {
     Nil,
     Append(T, T),
     Group(T),
+    FlatAlt(T, T),
     Nest(usize, T),
     Space,
     Newline,
@@ -256,6 +257,14 @@ impl<'a, A> Doc<'a, BoxDoc<'a, A>, A> {
         result
     }
 
+    #[inline]
+    pub fn flat_alt<D>(self, doc: D) -> Doc<'a, BoxDoc<'a, A>, A>
+    where
+        D: Into<Doc<'a, BoxDoc<'a, A>, A>>,
+    {
+        DocBuilder(&BOX_ALLOCATOR, self).flat_alt(doc).into()
+    }
+
     /// Mark this document as a group.
     ///
     /// Groups are layed out on a single line if possible.  Within a group, all basic documents with
@@ -271,6 +280,12 @@ impl<'a, A> Doc<'a, BoxDoc<'a, A>, A> {
     #[inline]
     pub fn nest(self, offset: usize) -> Doc<'a, BoxDoc<'a, A>, A> {
         DocBuilder(&BOX_ALLOCATOR, self).nest(offset).into()
+    }
+
+    /// Acts like `space` but behaves like `nil` if grouped on a single line
+    #[inline]
+    pub fn space_() -> Doc<'a, BoxDoc<'a, A>, A> {
+        BOX_ALLOCATOR.space_().into()
     }
 
     #[inline]
@@ -444,6 +459,11 @@ pub trait DocAllocator<'a, A = ()> {
         DocBuilder(self, Doc::Space)
     }
 
+    #[inline]
+    fn space_(&'a self) -> DocBuilder<'a, Self, A> {
+        self.newline().flat_alt(self.nil())
+    }
+
     /// Allocate a document containing the text `t.to_string()`.
     ///
     /// The given text must not contain line breaks.
@@ -517,6 +537,19 @@ where
         DocBuilder(allocator, doc)
     }
 
+    #[inline]
+    pub fn flat_alt<E>(self, that: E) -> DocBuilder<'a, D, A>
+    where
+        E: Into<Doc<'a, D::Doc, A>>,
+    {
+        let DocBuilder(allocator, this) = self;
+        let that = that.into();
+        DocBuilder(
+            allocator,
+            Doc::FlatAlt(allocator.alloc(this.into()), allocator.alloc(that)),
+        )
+    }
+
     /// Mark this document as a group.
     ///
     /// Groups are layed out on a single line if possible.  Within a group, all basic documents with
@@ -588,11 +621,13 @@ impl<'a, A> DocAllocator<'a, A> for Arena<'a, A> {
     #[inline]
     fn alloc(&'a self, doc: Doc<'a, Self::Doc, A>) -> Self::Doc {
         RefDoc(match doc {
-            // Return 'static references for unit variants to save a small
-            // amount of space in the arena
+            // Return 'static references for common variants to avoid some allocations
             Doc::Nil => &Doc::Nil,
             Doc::Space => &Doc::Space,
             Doc::Newline => &Doc::Newline,
+            Doc::FlatAlt(RefDoc(Doc::Newline), RefDoc(Doc::Nil)) => {
+                &Doc::FlatAlt(RefDoc(&Doc::Newline), RefDoc(&Doc::Nil))
+            }
             _ => Arena::alloc(self, doc),
         })
     }
@@ -714,5 +749,24 @@ mod tests {
         );
 
         test!(doc, "test\ntest");
+    }
+
+    #[test]
+    fn tuple() {
+        let doc = Doc::<_>::group(
+            Doc::text("(")
+                .append(
+                    Doc::space_()
+                        .append(Doc::text("test"))
+                        .append(Doc::space())
+                        .append(Doc::text("test"))
+                        .nest(2),
+                )
+                .append(Doc::space_())
+                .append(Doc::text(")")),
+        );
+
+        test!(5, doc, "(\n  test\n  test\n)");
+        test!(100, doc, "(test test)");
     }
 }

--- a/src/render.rs
+++ b/src/render.rs
@@ -238,6 +238,9 @@ where
                             }
                             fcmds.push((ind, mode, doc));
                         }
+                        Doc::FlatAlt(_, ref doc) => {
+                            fcmds.push((ind, mode, &**doc));
+                        }
                         Doc::Group(ref doc) => {
                             fcmds.push((ind, mode, doc));
                         }
@@ -282,6 +285,14 @@ where
                 }
                 bcmds.push((ind, mode, doc));
             }
+            Doc::FlatAlt(ref b, ref f) => bcmds.push((
+                ind,
+                mode,
+                match mode {
+                    Mode::Break => b,
+                    Mode::Flat => f,
+                },
+            )),
             Doc::Group(ref doc) => match mode {
                 Mode::Flat => {
                     bcmds.push((ind, Mode::Flat, doc));


### PR DESCRIPTION
`FlatAlt` makes is possible to have different formatting depenending on
if a document fits on a single line or needs multiple lines.

Inspired by https://hackage.haskell.org/package/prettyprinter but has a
slightly different implementation since `Group` is an explicit
constructor here instead of being implemented throug `Union` (which is
unimplemented)