### PR TITLE
feat: Always report documents containing newlines as not fitting

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ termcolor = { version = "0.3", optional = true }
 
 [dev-dependencies]
 tempfile = "2.1.4"
+difference = "2"
 
 [[example]]
 name = "trees"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -766,6 +766,13 @@ mod tests {
     }
 
     #[test]
+    fn newline_after_group_does_not_affect_it() {
+        let doc = Doc::<_>::text("x").append(Doc::space()).append("y").group();
+
+        test!(100, doc.append(Doc::newline()), "x y\n");
+    }
+
+    #[test]
     fn block() {
         let doc = Doc::<_>::group(
             Doc::text("{")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -693,13 +693,15 @@ impl<'a, A> DocAllocator<'a, A> for BoxAllocator {
 
 #[cfg(test)]
 mod tests {
+    extern crate difference;
+
     use super::*;
 
     macro_rules! test {
         ($size:expr, $actual:expr, $expected:expr) => {
             let mut s = String::new();
             $actual.render_fmt($size, &mut s).unwrap();
-            assert_eq!(s, $expected);
+            difference::assert_diff!(&s, $expected, "\n", 0);
         };
         ($actual:expr, $expected:expr) => {
             test!(70, $actual, $expected)

--- a/src/render.rs
+++ b/src/render.rs
@@ -255,7 +255,7 @@ where
                                 return true;
                             }
                         },
-                        Doc::Newline => return true,
+                        Doc::Newline => return mode == Mode::Break,
                         Doc::Text(ref str) => {
                             rem -= str.len() as isize;
                         }
@@ -322,25 +322,6 @@ where
             Doc::Newline => {
                 write_newline(ind, out)?;
                 pos = ind;
-
-                // Since this newline caused an early break we don't know if the remaining
-                // documents fit the next line so recalculate if they fit
-                fcmds.clear();
-                let docs = bcmds.len()
-                    - bcmds
-                        .iter()
-                        .rev()
-                        .position(|t| t.1 == Mode::Break)
-                        .unwrap_or_else(|| bcmds.len());
-                fcmds.extend_from_slice(&bcmds[docs..]);
-                if let Some(next) = fcmds.pop() {
-                    let rem = width as isize - pos as isize;
-                    if !fitting(next, &bcmds, &mut fcmds, rem) {
-                        for &mut (_, ref mut mode, _) in &mut bcmds[docs..] {
-                            *mode = Mode::Break;
-                        }
-                    }
-                }
             }
             Doc::Text(ref s) => {
                 out.write_str_all(s)?;


### PR DESCRIPTION
The old behaviour would say that the document fit because everything
before the newline could actually fit on it. However this forces the
layout algorithm to fixup any documents after the newline in a way that
causes inconsistent results within a group.

With this change users must again explicitly ask for everything before
the newline to be explicitly grouped and in exchange any outer grouping
that ends up containing a `newline` will behave more consistently with
`space` documents in that same group.

BREAKING CHANGE

Documents such as `doc.append(Doc::newline()).group()` can retain the
previous behaviour as `doc.group().append(Doc::newline()).group()`