### PR TITLE
fix: Pop annotations correctly if they are directly nested

### DIFF
--- a/src/render.rs
+++ b/src/render.rs
@@ -380,7 +380,7 @@ where
 
             break;
         }
-        if annotation_levels.last() == Some(&bcmds.len()) {
+        while annotation_levels.last() == Some(&bcmds.len()) {
             annotation_levels.pop();
             out.pop_annotation()?;
         }


### PR DESCRIPTION
Fixes #56