### PR TITLE
Make RefDoc transparent

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1138,7 +1138,7 @@ where
 }
 
 /// Newtype wrapper for `&Doc`
-pub struct RefDoc<'a, A = ()>(&'a Doc<'a, RefDoc<'a, A>, A>);
+pub struct RefDoc<'a, A = ()>(pub &'a Doc<'a, RefDoc<'a, A>, A>);
 
 impl<A> Copy for RefDoc<'_, A> {}
 impl<A> Clone for RefDoc<'_, A> {


### PR DESCRIPTION
I needed this in order to declare some static `Doc`s with references between them. (Alternatively, `RefDoc` could have a constructor, but given that the deref instance gives you the other direction it's not much different from just making the contents public.)