### PR TITLE
feat: Reject the left side of union documents if it does not fit

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -174,17 +174,18 @@ pub enum Doc<'a, T: DocPtr<'a, A>, A = ()> {
 
 pub type SmallText = arrayvec::ArrayString<[u8; 22]>;
 
-fn append_docs<'a, 'd, T, A>(doc: &'d Doc<'a, T, A>, consumer: &mut impl FnMut(&'d Doc<'a, T, A>))
+fn append_docs<'a, 'd, T, A>(mut doc: &'d Doc<'a, T, A>, consumer: &mut impl FnMut(&'d Doc<'a, T, A>))
 where
-    T: DocPtr<'a, A> + fmt::Debug,
-    A: fmt::Debug,
+    T: DocPtr<'a, A>,
 {
-    match doc {
-        Doc::Append(l, r) => {
-            append_docs(l, consumer);
-            append_docs(r, consumer);
+    loop {
+        match doc {
+            Doc::Append(l, r) => {
+                append_docs(l, consumer);
+                doc = r;
+            }
+            _ => break consumer(doc),
         }
-        _ => consumer(doc),
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -830,13 +830,23 @@ where
 }
 
 /// Either a `Doc` or a pointer to a `Doc` (`D`)
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub enum BuildDoc<'a, D, A>
 where
     D: DocPtr<'a, A>,
 {
     DocPtr(D),
     Doc(Doc<'a, D, A>),
+}
+
+impl<'a, D, A> fmt::Debug for BuildDoc<'a, D, A>
+where
+    D: DocPtr<'a, A> + fmt::Debug,
+    A: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        (**self).fmt(f)
+    }
 }
 
 impl<'a, D, A> Deref for BuildDoc<'a, D, A>
@@ -954,6 +964,9 @@ where
     /// line.
     #[inline]
     pub fn group(self) -> DocBuilder<'a, D, A> {
+        if let Doc::Group(_) = *self.1 {
+            return self;
+        }
         let DocBuilder(allocator, this) = self;
         DocBuilder(allocator, Doc::Group(allocator.alloc_cow(this)).into())
     }

--- a/src/render.rs
+++ b/src/render.rs
@@ -157,9 +157,9 @@ where
 }
 
 macro_rules! make_spaces {
-            () => { "" };
-            ($s: tt $($t: tt)*) => { concat!("          ", make_spaces!($($t)*)) };
-        }
+    () => { "" };
+    ($s: tt $($t: tt)*) => { concat!("          ", make_spaces!($($t)*)) };
+}
 
 pub(crate) const SPACES: &str = make_spaces!(,,,,,,,,,,);
 
@@ -346,29 +346,27 @@ where
                     };
                     continue;
                 }
-                Doc::Group(ref doc) => match mode {
-                    Mode::Flat => {
-                        cmd = (ind, Mode::Flat, doc);
-                        continue;
+                Doc::Group(ref doc) => {
+                    match mode {
+                        Mode::Flat => (),
+                        Mode::Break => {
+                            if fitting(
+                                &temp_arena,
+                                doc,
+                                &bcmds,
+                                &mut fcmds,
+                                pos,
+                                width,
+                                ind,
+                                |mode| mode == Mode::Break,
+                            ) {
+                                cmd.1 = Mode::Flat;
+                            }
+                        }
                     }
-                    Mode::Break => {
-                        cmd = if fitting(
-                            &temp_arena,
-                            doc,
-                            &bcmds,
-                            &mut fcmds,
-                            pos,
-                            width,
-                            ind,
-                            |mode| mode == Mode::Break,
-                        ) {
-                            (ind, Mode::Flat, &**doc)
-                        } else {
-                            (ind, Mode::Break, doc)
-                        };
-                        continue;
-                    }
-                },
+                    cmd.2 = doc;
+                    continue;
+                }
                 Doc::Nest(off, ref doc) => {
                     cmd = ((ind as isize).saturating_add(off) as usize, mode, doc);
                     continue;


### PR DESCRIPTION
And add `Fail` as a way to immediately abort document formatting if it is encountered.

BREAKING CHANGE

Adds the `Fail` variant to `Doc`

Changes `RenderAnnotated` to take a lifetime