### PR TITLE
Fix negative nest offset not saturating correctly

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1839,6 +1839,24 @@ mod tests {
     }
 
     #[test]
+    fn block_with_hardline_negative_nest() {
+        let doc: RcDoc<()> = RcDoc::group(
+            RcDoc::text("{")
+                .append(
+                    RcDoc::line()
+                        .append(RcDoc::text("test"))
+                        .append(RcDoc::hardline())
+                        .append(RcDoc::text("test"))
+                        .nest(-2),
+                )
+                .append(RcDoc::line())
+                .append(RcDoc::text("}")),
+        );
+
+        test!(10, doc, "{\ntest\ntest\n}");
+    }
+
+    #[test]
     fn line_comment() {
         let doc: BoxDoc<()> = BoxDoc::group(
             BoxDoc::text("{")

--- a/src/render.rs
+++ b/src/render.rs
@@ -470,7 +470,14 @@ where
                         continue;
                     }
                     Doc::Nest(off, ref doc) => {
-                        cmd = ((ind as isize).saturating_add(off) as usize, mode, doc);
+                        // Once https://doc.rust-lang.org/std/primitive.usize.html#method.saturating_add_signed is stable
+                        // this can be replaced
+                        let new_ind = if off >= 0 {
+                            ind.saturating_add(off as usize)
+                        } else {
+                            ind.saturating_sub(off.unsigned_abs())
+                        };
+                        cmd = (new_ind, mode, doc);
                         continue;
                     }
                     Doc::Hardline => {


### PR DESCRIPTION
A negative nest offset could cause the calculation
`(ind as isize).saturating_add(off)` to result in a negative value,
when this was casted back to `usize` the value would end up as a large
positive number which ended up causing `write_spaces` to run until
memory allocation would fail.

Unfortunately `usize::saturating_add_signed` is unstable so we need to
manually implement similar logic.