### PR TITLE
remove mostly unused log dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ edition = "2018"
 features = ["termcolor"]
 
 [dependencies]
-log = "0.4"
 arrayvec = "0.5"
 typed-arena = "2.0.0"
 termcolor = { version = "1.1.0", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1892,7 +1892,6 @@ mod tests {
         BoxDoc::softline().append(BoxDoc::nesting(move |n| {
             let doc = doc.clone();
             BoxDoc::column(move |c| {
-                log::trace!("{} == {}", n, c);
                 if n == c {
                     BoxDoc::text("  ").append(doc.clone()).nest(2)
                 } else {


### PR DESCRIPTION
This was a heavy dependency for a single trace. It could be removed.