### PR TITLE
Remove unused `log` and `env_log` dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ edition = "2018"
 features = ["termcolor"]
 
 [dependencies]
-log = "0.4"
 arrayvec = "0.5"
 typed-arena = "2.0.0"
 termcolor = { version = "1.1.0", optional = true }
@@ -23,7 +22,6 @@ unicode-segmentation = "1"
 [dev-dependencies]
 criterion = "0.3"
 difference = "2"
-env_logger = "0.9"
 tempfile = "3.1.0"
 
 [[example]]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1892,7 +1892,6 @@ mod tests {
         BoxDoc::softline().append(BoxDoc::nesting(move |n| {
             let doc = doc.clone();
             BoxDoc::column(move |c| {
-                log::trace!("{} == {}", n, c);
                 if n == c {
                     BoxDoc::text("  ").append(doc.clone()).nest(2)
                 } else {
@@ -1904,8 +1903,6 @@ mod tests {
 
     #[test]
     fn hang_lambda1() {
-        let _ = env_logger::try_init();
-
         let doc = chain![
             chain!["let", BoxDoc::line(), "x", BoxDoc::line(), "="].group(),
             nest_on_line(chain![


### PR DESCRIPTION
These dependencies were only used in a single test, and the test still passed when the log lines were removed. I guess it was leftover from debugging?