### PR TITLE
Avoid stack overflow when rendering many appended docs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2167,4 +2167,26 @@ mod tests {
 
         test!(8, doc, "abc 123");
     }
+
+    #[test]
+    fn stress_append_left_assoc() {
+        let arena = Arena::new();
+        let mut doc: DocBuilder<'_, Arena<'_, _>, char> = arena.nil();
+        for _ in 0..100000 {
+            doc = doc.append("a");
+        }
+        let mut s = String::new();
+        doc.render_fmt(80, &mut s).unwrap();
+    }
+
+    #[test]
+    fn stress_append_right_assoc() {
+        let arena = Arena::new();
+        let mut doc: RefDoc<'_, char> = arena.nil().into_doc();
+        for _ in 0..100000 {
+            doc = arena.text("a").append(doc).into_doc();
+        }
+        let mut s = String::new();
+        doc.render_fmt(80, &mut s).unwrap();
+    }
 }

--- a/src/render.rs
+++ b/src/render.rs
@@ -274,8 +274,7 @@ where
         // to push and directly pop `Append` documents)
         match doc {
             Doc::Append(l, r) => {
-                let d = append_docs(r, consumer);
-                consumer(d);
+                consumer(r);
                 doc = l;
             }
             _ => return doc,


### PR DESCRIPTION
On `main`, `stress_append_right_assoc` causes stack overflow.

Closes https://github.com/Marwes/pretty.rs/issues/86